### PR TITLE
Compatibility with jQuery 1.6

### DIFF
--- a/src/strength.js
+++ b/src/strength.js
@@ -111,7 +111,7 @@
 
 
 
-            $(document.body).on('click', '.'+this.options.strengthButtonClass, function(e) {
+            $(document.body).delegate('.'+this.options.strengthButtonClass, 'click', function(e) {
                 e.preventDefault();
 
                thisclass = 'hide_'+$(this).attr('class');


### PR DESCRIPTION
I am working on a project that needs to use jQuery 1.6.
This small change makes strength.js compatible with old versions of jQuery.