### PR TITLE
Host element classes now picked up

### DIFF
--- a/src/strength.js
+++ b/src/strength.js
@@ -92,7 +92,7 @@
 
             thisid = this.$elem.attr('id');
 
-            this.$elem.addClass(this.options.strengthClass).attr('data-password',thisid).after('<input style="display:none" class="'+this.options.strengthClass+'" data-password="'+thisid+'" type="text" name="" value=""><a data-password-button="'+thisid+'" href="" class="'+this.options.strengthButtonClass+'">'+this.options.strengthButtonText+'</a><div class="'+this.options.strengthMeterClass+'"><div data-meter="'+thisid+'">Strength</div></div>');
+            this.$elem.addClass(this.options.strengthClass).attr('data-password',thisid).after('<input style="display:none" class="'+this.options.strengthClass+' '+this.$elem.attr('class')+'" data-password="'+thisid+'" type="text" name="" value=""><a data-password-button="'+thisid+'" href="" class="'+this.options.strengthButtonClass+'">'+this.options.strengthButtonText+'</a><div class="'+this.options.strengthMeterClass+'"><div data-meter="'+thisid+'">Strength</div></div>');
              
             this.$elem.bind('keyup keydown', function(event) {
                 thisval = $('#'+thisid).val();


### PR DESCRIPTION
Great plugin, thanks for sharing.

Just trying it out now, noticed that it wasn't copying classes on the password element onto the input[type=text] element. Thought it made sense so pushing it back in case you want it.

Also I noticed the `.min.js` file is functionally different, assume it's out of date but not sure how you prefer to compress it.
